### PR TITLE
Enhance in-memory operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ goconfig [![Build Status](https://drone.io/github.com/Unknwon/goconfig/status.pn
 - This library is under bug fix only mode, which means no more features will be added.
 - I'm continuing working on better Go code with a different library: [ini](https://github.com/go-ini/ini).
 
+** FORK information **
+
+This fork was created by Klaus Post in Jan 2016 to support encrypted configuration. Main changes are:
+
+* `LoadFromData` no longer writes data to temporary file before loading.
+* `LoadFromData` takes an `io.Reader` for input instead of byte slice.
+* `SaveConfigData` added, which writes configuration to an arbitrary writer.
+* `ReloadData` added to reload data from memory.
+
+Note that you cannot mix in-memory configuration with on-disk configuration.
+
 ## About
 
 Package goconfig is a easy-use, comments-support configuration file parser for the Go Programming Language, which provides a structure similar to what you would find on Microsoft Windows INI files.

--- a/goconfig_test.go
+++ b/goconfig_test.go
@@ -15,6 +15,7 @@
 package goconfig
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -341,7 +342,7 @@ func TestArray(t *testing.T) {
 
 func TestLoadFromData(t *testing.T) {
 	Convey("Load config file from data", t, func() {
-		c, err := LoadFromData([]byte(""))
+		c, err := LoadFromData(bytes.NewBuffer([]byte("")))
 		So(err, ShouldBeNil)
 		So(c, ShouldNotBeNil)
 	})

--- a/write.go
+++ b/write.go
@@ -16,6 +16,7 @@ package goconfig
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"strings"
 )
@@ -23,14 +24,8 @@ import (
 // Write spaces around "=" to look better.
 var PrettyFormat = true
 
-// SaveConfigFile writes configuration file to local file system
-func SaveConfigFile(c *ConfigFile, filename string) (err error) {
-	// Write configuration file by filename.
-	var f *os.File
-	if f, err = os.Create(filename); err != nil {
-		return err
-	}
-
+// SaveConfigData writes configuration to a writer
+func SaveConfigData(c *ConfigFile, out io.Writer) (err error) {
 	equalSign := "="
 	if PrettyFormat {
 		equalSign = " = "
@@ -101,7 +96,21 @@ func SaveConfigFile(c *ConfigFile, filename string) (err error) {
 		}
 	}
 
-	if _, err = buf.WriteTo(f); err != nil {
+	if _, err := buf.WriteTo(out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SaveConfigFile writes configuration file to local file system
+func SaveConfigFile(c *ConfigFile, filename string) (err error) {
+	// Write configuration file by filename.
+	var f *os.File
+	if f, err = os.Create(filename); err != nil {
+		return err
+	}
+
+	if err := SaveConfigData(c, f); err != nil {
 		return err
 	}
 	return f.Close()


### PR DESCRIPTION
- `LoadFromData` no longer writes data to temporary file before loading.
- `LoadFromData` takes an `io.Reader` for input instead of byte slice.
- `SaveConfigData` added, which writes configuration to an arbitrary writer.
- `ReloadData` added to reload data from memory.

Note that you cannot mix in-memory configuration with on-disk configuration.
